### PR TITLE
Make repository LCA compliant.

### DIFF
--- a/src/DotNetStatus/Controllers/FxApiController.cs
+++ b/src/DotNetStatus/Controllers/FxApiController.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Microsoft.AspNet.Mvc;
 using Microsoft.Fx.Portability;
 using System;

--- a/src/DotNetStatus/Controllers/HomeController.cs
+++ b/src/DotNetStatus/Controllers/HomeController.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNet.Mvc;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNet.Mvc;
 
 // For more information on enabling MVC for empty projects, visit http://go.microsoft.com/fwlink/?LinkID=397860
 

--- a/src/DotNetStatus/Controllers/SubmissionController.cs
+++ b/src/DotNetStatus/Controllers/SubmissionController.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNet.Mvc;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNet.Mvc;
 using Microsoft.Fx.Portability;
 using Microsoft.Fx.Portability.ObjectModel;
 using System;

--- a/src/DotNetStatus/Controllers/UsageController.cs
+++ b/src/DotNetStatus/Controllers/UsageController.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNet.Mvc;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNet.Mvc;
 using Microsoft.Fx.Portability;
 using Microsoft.Fx.Portability.ObjectModel;
 using System.Collections.Generic;

--- a/src/DotNetStatus/Gruntfile.js
+++ b/src/DotNetStatus/Gruntfile.js
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 /// <binding BeforeBuild='bower, concat' ProjectOpened='bower:install' />
 /*
 This file in the main entry point for defining grunt tasks and using grunt plugins.

--- a/src/DotNetStatus/Startup.cs
+++ b/src/DotNetStatus/Startup.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNet.Builder;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNet.Builder;
 using Microsoft.AspNet.Diagnostics;
 using Microsoft.AspNet.Hosting;
 using Microsoft.Framework.ConfigurationModel;

--- a/src/DotNetStatus/Views/FxApi/Index.cshtml
+++ b/src/DotNetStatus/Views/FxApi/Index.cshtml
@@ -1,3 +1,7 @@
+@*  Copyright (c) Microsoft. All rights reserved.
+    Licensed under the MIT license. See LICENSE file in the project root for full license information.
+*@
+
 @model Microsoft.Fx.Portability.ApiInformation
 @using DotNetStatus
 

--- a/src/DotNetStatus/Views/Home/Index.cshtml
+++ b/src/DotNetStatus/Views/Home/Index.cshtml
@@ -1,4 +1,8 @@
-﻿@{
+@*  Copyright (c) Microsoft. All rights reserved.
+    Licensed under the MIT license. See LICENSE file in the project root for full license information.
+*@
+
+@{
     ViewBag.Title = "Index";
 }
 

--- a/src/DotNetStatus/Views/Shared/Error.cshtml
+++ b/src/DotNetStatus/Views/Shared/Error.cshtml
@@ -1,4 +1,8 @@
-﻿@{
+@*  Copyright (c) Microsoft. All rights reserved.
+    Licensed under the MIT license. See LICENSE file in the project root for full license information.
+*@
+
+@{
     Layout = null;
 }
 

--- a/src/DotNetStatus/Views/Shared/_Layout.cshtml
+++ b/src/DotNetStatus/Views/Shared/_Layout.cshtml
@@ -1,4 +1,8 @@
-﻿<!DOCTYPE html>
+﻿@*  Copyright (c) Microsoft. All rights reserved.
+    Licensed under the MIT license. See LICENSE file in the project root for full license information.
+*@
+
+<!DOCTYPE html>
 <html>
 <head>
     <meta charset="utf-8" />

--- a/src/DotNetStatus/Views/Submission/Index.cshtml
+++ b/src/DotNetStatus/Views/Submission/Index.cshtml
@@ -1,4 +1,8 @@
-﻿@using Microsoft.Fx.Portability;
+@*  Copyright (c) Microsoft. All rights reserved.
+    Licensed under the MIT license. See LICENSE file in the project root for full license information.
+*@
+
+@using Microsoft.Fx.Portability;
 @using Microsoft.Fx.Portability.ObjectModel;
 
 @{

--- a/src/DotNetStatus/Views/Submission/_Find.cshtml
+++ b/src/DotNetStatus/Views/Submission/_Find.cshtml
@@ -1,4 +1,8 @@
-﻿@using Microsoft.Fx.Portability;
+@*  Copyright (c) Microsoft. All rights reserved.
+    Licensed under the MIT license. See LICENSE file in the project root for full license information.
+*@
+
+@using Microsoft.Fx.Portability;
 @using Microsoft.Fx.Portability.ObjectModel;
 
 @{

--- a/src/DotNetStatus/Views/Submission/_SubmissionResult.cshtml
+++ b/src/DotNetStatus/Views/Submission/_SubmissionResult.cshtml
@@ -1,4 +1,8 @@
-﻿@model Microsoft.Fx.Portability.ObjectModel.AnalyzeResponse
+@*  Copyright (c) Microsoft. All rights reserved.
+    Licensed under the MIT license. See LICENSE file in the project root for full license information.
+*@
+
+@model Microsoft.Fx.Portability.ObjectModel.AnalyzeResponse
 
 @if (Model.MissingDependencies.Any())
 {

--- a/src/DotNetStatus/Views/Usage/Index.cshtml
+++ b/src/DotNetStatus/Views/Usage/Index.cshtml
@@ -1,3 +1,7 @@
+@*  Copyright (c) Microsoft. All rights reserved.
+    Licensed under the MIT license. See LICENSE file in the project root for full license information.
+*@
+
 @model Microsoft.Fx.Portability.ObjectModel.UsageDataCollection
 
 @{

--- a/src/DotNetStatus/Views/Usage/_Error.cshtml
+++ b/src/DotNetStatus/Views/Usage/_Error.cshtml
@@ -1,1 +1,5 @@
-﻿<div class="alert alert-danger" role="alert">There was a problem loading the page.  Please try again in a few minutes.</div>
+@*  Copyright (c) Microsoft. All rights reserved.
+    Licensed under the MIT license. See LICENSE file in the project root for full license information.
+*@
+
+<div class="alert alert-danger" role="alert">There was a problem loading the page.  Please try again in a few minutes.</div>

--- a/src/DotNetStatus/Views/Usage/_Legend.cshtml
+++ b/src/DotNetStatus/Views/Usage/_Legend.cshtml
@@ -1,4 +1,8 @@
-﻿
+@*  Copyright (c) Microsoft. All rights reserved.
+    Licensed under the MIT license. See LICENSE file in the project root for full license information.
+*@
+
+
 <div class="row">
     <div class="col-md-12">
         This data is a summary of the data we have collected from ApiPort (console and VS extension) submissions.  This data is from @Model.SubmissionCount.ToString("N0") submissions.

--- a/src/DotNetStatus/Views/Usage/_Usage.cshtml
+++ b/src/DotNetStatus/Views/Usage/_Usage.cshtml
@@ -1,4 +1,8 @@
-﻿@model Microsoft.Fx.Portability.ObjectModel.UsageDataCollection
+@*  Copyright (c) Microsoft. All rights reserved.
+    Licensed under the MIT license. See LICENSE file in the project root for full license information.
+*@
+
+@model Microsoft.Fx.Portability.ObjectModel.UsageDataCollection
 
 @if (Model == null)
 {

--- a/src/DotNetStatus/Views/Usage/_UsageGrid.cshtml
+++ b/src/DotNetStatus/Views/Usage/_UsageGrid.cshtml
@@ -1,4 +1,8 @@
-﻿@model Microsoft.Fx.Portability.ObjectModel.UsageDataCollection
+@*  Copyright (c) Microsoft. All rights reserved.
+    Licensed under the MIT license. See LICENSE file in the project root for full license information.
+*@
+
+@model Microsoft.Fx.Portability.ObjectModel.UsageDataCollection
 
 @using Microsoft.Fx.Portability.ObjectModel;
 

--- a/src/DotNetStatus/Views/_ViewStart.cshtml
+++ b/src/DotNetStatus/Views/_ViewStart.cshtml
@@ -1,3 +1,7 @@
-﻿@{
+@*  Copyright (c) Microsoft. All rights reserved.
+    Licensed under the MIT license. See LICENSE file in the project root for full license information.
+*@
+
+@{
     Layout = "/Views/Shared/_Layout.cshtml";
 }

--- a/src/DotNetStatus/assets/js/AppInsights.js
+++ b/src/DotNetStatus/assets/js/AppInsights.js
@@ -1,4 +1,7 @@
-﻿var appInsights = window.appInsights || function (config) {
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+var appInsights = window.appInsights || function (config) {
     function s(config) { t[config] = function () { var i = arguments; t.queue.push(function () { t[config].apply(t, i) }) } } var t = { config: config }, r = document, f = window, e = "script", o = r.createElement(e), i, u; for (o.src = config.url || "//az416426.vo.msecnd.net/scripts/a/ai.0.js", r.getElementsByTagName(e)[0].parentNode.appendChild(o), t.cookie = r.cookie, t.queue = [], i = ["Event", "Exception", "Metric", "PageView", "Trace"]; i.length;) s("track" + i.pop()); return config.disableExceptionTracking || (i = "onerror", s("_" + i), u = f[i], f[i] = function (config, r, f, e, o) { var s = u && u(config, r, f, e, o); return s !== !0 && t["_" + i](config, r, f, e, o), s }), t
 }({
     instrumentationKey: "1d7e09ed-05de-4699-97a4-2edbfdb0e139"

--- a/src/DotNetStatus/assets/js/PopoverHelpers.js
+++ b/src/DotNetStatus/assets/js/PopoverHelpers.js
@@ -1,4 +1,7 @@
-﻿function InitializePopovers() {
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+function InitializePopovers() {
     $(".popup-marker").popover();
     $(".popup-marker").on('click', function (e) { e.preventDefault(); return true; });
 

--- a/src/DotNetStatus/assets/js/Search.js
+++ b/src/DotNetStatus/assets/js/Search.js
@@ -1,4 +1,7 @@
-﻿$(document).ready(function () {
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+$(document).ready(function () {
     var $searchTextBox = $("#searchTextBox");
     var $searchButton = $("#searchButton");
     var $hiddenDocId = $("#docId");

--- a/src/DotNetStatus/bower.json
+++ b/src/DotNetStatus/bower.json
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 {
     "name": "DotNetStatus",
     "private": true,

--- a/src/DotNetStatus/config.json
+++ b/src/DotNetStatus/config.json
@@ -1,3 +1,6 @@
-﻿{
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+{
     "ApiPortService": "https://portability.cloudapp.net"
 }

--- a/src/DotNetStatus/package.json
+++ b/src/DotNetStatus/package.json
@@ -1,4 +1,7 @@
-﻿{
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+{
     "version": "0.0.0",
     "name": "DotNetStatus",
     "devDependencies": {

--- a/src/DotNetStatus/project.json
+++ b/src/DotNetStatus/project.json
@@ -1,4 +1,7 @@
-﻿{
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+{
     "webroot": "wwwroot",
     "version": "1.0.0-*",
     "exclude": [


### PR DESCRIPTION
Add MIT license to the files.

There was a push to have the repository structure look like:
- src
  - DotNetStatus
    - src
    - test

However, ASP.NET vNext that does not allow for this: [How to change Nuget package name](https://forums.asp.net/t/2029096.aspx?How+to+change+the+Nuget+package+name+on+build)
