### PR TITLE
Move DotNetStatus.sln to top-level

### DIFF
--- a/DotNetStatus.sln
+++ b/DotNetStatus.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
 VisualStudioVersion = 14.0.22310.1
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "DotNetStatus", "DotNetStatus\DotNetStatus.kproj", "{156E5AB6-C13D-4D12-AD10-2AFA192DB3B5}"
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "DotNetStatus", "src\DotNetStatus\DotNetStatus.kproj", "{156E5AB6-C13D-4D12-AD10-2AFA192DB3B5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
This changes moves DotNetStatus to the top of the repository.
