### PR TITLE
Add reference to dotnet-apiport feed

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -3,5 +3,6 @@
   <packageSources>
     <add key="AspNetVNext" value="https://www.myget.org/F/aspnetvnext/api/v2" />
     <add key="nuget.org" value="https://nuget.org/api/v2/" />
+    <add key="dotnet-apiport" value="https://www.myget.org/F/dotnet-apiport" />
   </packageSources>
 </configuration>

--- a/src/DotNetStatus/project.json
+++ b/src/DotNetStatus/project.json
@@ -12,7 +12,7 @@
         "Microsoft.AspNet.Diagnostics": "1.0.0-beta1",
         "Microsoft.AspNet.StaticFiles": "1.0.0-beta1",
         "Microsoft.Framework.ConfigurationModel.Json": "1.0.0-beta1",
-        "Microsoft.Fx.Portability": "1.0.0"
+        "Microsoft.Fx.Portability": "1.0.0-*"
     },
     "commands": {
         /* Change the port number when you are self hosting this application */


### PR DESCRIPTION
Allows developers to use the myget feed for the Microsoft.Fx.Portability library.
