### PR TITLE
Fix FxApi view to use Markdown instead of Html

### DIFF
--- a/src/DotNetStatus/Views/FxApi/Index.cshtml
+++ b/src/DotNetStatus/Views/FxApi/Index.cshtml
@@ -50,7 +50,7 @@
                     <h3 class="panel-title">@additional.Title</h3>
                 </div>
             @*<div class="panel-body">@Html.Markdown(additional.Html)</div>*@
-                <div class="panel-body">@additional.Html</div>
+                <div class="panel-body">@additional.Markdown</div>
             </div>
         }
     }


### PR DESCRIPTION
Fixes the view after updates from the Microsoft.Fx.Portability library.
