### PR TITLE
Fix broken css and js

### DIFF
--- a/src/DotNetStatus/Views/Shared/_Layout.cshtml
+++ b/src/DotNetStatus/Views/Shared/_Layout.cshtml
@@ -19,25 +19,24 @@
     <link rel="icon" href="~/img/dotnet.ico" />
 
     <environment names="Development">
-        <link rel="stylesheet" href="~/lib/bootstrap/bootstrap.css" />
+        <link rel="stylesheet" href="~/lib/bootstrap/css/bootstrap.css" />
         <link rel="stylesheet" href="~/lib/jquery-ui-smoothness/jquery-ui.css" />
-        <link rel="stylesheet" href="~/css/site.css" asp-file-version="true" />
 
         <script src="~/lib/jquery/jquery.js"></script>
         <script src="~/lib/jquery-ui/jquery-ui.js"></script>
-        <script src="~/lib/bootstrap/bootstrap.js"></script>
-        <script src="~/js/site.js" asp-file-version="true"></script>
+        <script src="~/lib/bootstrap/js/bootstrap.js"></script>
     </environment>
     <environment names="Staging,Production">
         <link rel="stylesheet" href="http://ajax.aspnetcdn.com/ajax/bootstrap/3.3.1/css/bootstrap.min.css" />
         <link rel="stylesheet" href="http://ajax.aspnetcdn.com/ajax/jquery.ui/1.11.2/themes/smoothness/jquery-ui.css" />
-        <link rel="stylesheet" href="~/css/site.css" asp-file-version="true" />
 
         <script src="http://ajax.aspnetcdn.com/ajax/jQuery/jquery-2.1.3.min.js"></script>
         <script src="http://ajax.aspnetcdn.com/ajax/jquery.ui/1.11.2/jquery-ui.min.js"></script>
         <script src="http://ajax.aspnetcdn.com/ajax/bootstrap/3.3.1/bootstrap.min.js"></script>
-        <script src="~/js/site.js" asp-file-version="true"></script>
     </environment>
+
+    <link rel="stylesheet" href="~/css/site.min.css" asp-file-version="true" />
+    <script src="~/js/site.min.js" asp-file-version="true"></script>
 
     @RenderSection("scripts", required: false)
     <meta name="description" content="Status of the .NET Framework" />

--- a/src/DotNetStatus/gulpfile.js
+++ b/src/DotNetStatus/gulpfile.js
@@ -17,6 +17,8 @@ paths.css = "assets/css/**/*.css";
 paths.minCss = paths.webroot + "css/**/*.min.css";
 paths.concatJsDest = paths.webroot + "js/site.min.js";
 paths.concatCssDest = paths.webroot + "css/site.min.css";
+paths.bower = "bower_components/";
+paths.lib = paths.webroot + "lib/";
 
 gulp.task("clean:js", function (cb) {
     rimraf(paths.concatJsDest, cb);
@@ -42,4 +44,20 @@ gulp.task("min:css", function () {
         .pipe(gulp.dest("."));
 });
 
+gulp.task("copy", function () {
+    var bower = {
+        "bootstrap": "bootstrap/dist/**/*.{js,map,css,ttf,svg,woff,eot}",
+        "jquery": "jquery/dist/jquery*.{js,map}",
+        "jquery-ui": "jquery-ui/jquery-ui.js",
+        "jquery-ui-smoothness": "jquery-ui-smoothness/jquery-ui.css"
+    };
+
+    for (var module in bower) {
+        gulp.src(paths.bower + bower[module])
+          .pipe(gulp.dest(paths.lib + module));
+    };
+});
+
 gulp.task("min", ["min:js", "min:css"]);
+
+gulp.task("build", ["copy", "min"]);

--- a/src/DotNetStatus/project.json
+++ b/src/DotNetStatus/project.json
@@ -37,6 +37,6 @@
     "**.vspscc"
   ],
   "scripts": {
-    "prepublish": [ "npm install", "bower install", "gulp clean", "gulp min" ]
+    "prepublish": [ "npm install", "bower install", "gulp clean", "gulp build" ]
   }
 }


### PR DESCRIPTION
The change to use gulp broke local development from a clean environment (ie it did not copy bower components needed for development).  This ensures that those are copied as well as all our custom js and css.